### PR TITLE
Removed duplicate sentence

### DIFF
--- a/public/json/warmaster-revolution/empire.json
+++ b/public/json/warmaster-revolution/empire.json
@@ -233,7 +233,7 @@
         "",
         "Targets suffering hits from a Steam Tank count their Armour value as one worse than normal - so 3+ counts as 4+, 4+ as 5+, whilst 6+ is ignored. A Steam Tank can shoot at charging enemy.",
         "",
-        "Because of its exceptionally heavy armour plating, a Steam Tank always counts as defended - so a 5 or 6 is normally required to inflict a hit from shooting or in combat. The Steam Tank fights combat like any other unit. Steam Tanks cannot be driven back or routed by shooting. Steam Tanks cannot be driven back or routed by shooting.",
+        "Because of its exceptionally heavy armour plating, a Steam Tank always counts as defended - so a 5 or 6 is normally required to inflict a hit from shooting or in combat. The Steam Tank fights combat like any other unit. Steam Tanks cannot be driven back or routed by shooting.",
         "",
         "If the player attempts to issue an order to a Steam Tank and rolls double six then the order is failed as usual and the machine does not move. Ignore the usual Blunder chart for heroes and wizards. Roll on the following Malfunction chart. Note that although a General cannot blunder he must still roll for malfunctions.",
         "",


### PR DESCRIPTION
The same sentence is repeated twice in the rules for the Empire's Steam Tank, I noticed this while printing the files.

Great project, thank you for your work!