### PR TITLE
Add The Battle of Five Armies rules.

### DIFF
--- a/public/json/warmaster-the-battle-of-five-armies/evil.json
+++ b/public/json/warmaster-the-battle-of-five-armies/evil.json
@@ -1,0 +1,271 @@
+{
+  "name": "Evil Army",
+  "version": "Warmaster The Battle of Five Armies",
+  "group": 1,
+  "order": 0,
+  "units": {
+    "Goblins": {
+      "order": 0,
+      "type": "Infantry",
+      "attack": "2/1",
+      "range": "15cm",
+      "hits": 3,
+      "size": 3,
+      "points": 30
+    },
+    "Goblin Guard": {
+      "order": 1,
+      "type": "Infantry",
+      "attack": 3,
+      "hits": 3,
+      "armour": "6+",
+      "size": 3,
+      "points": 45,
+      "max": 1
+    },
+    "Hill Trolls": {
+      "order": 2,
+      "type": "Infantry",
+      "attack": 5,
+      "hits": 3,
+      "armour": "5+",
+      "size": 3,
+      "points": 100,
+      "max": 1
+    },
+    "Wolf Riders": {
+      "order": 3,
+      "type": "Cavalry",
+      "attack": "2/1",
+      "range": "15cm",
+      "hits": 3,
+      "armour": "6+",
+      "size": 3,
+      "points": 60,
+      "specialRules": [
+        "Goblins"
+      ]
+    },
+    "Wargs": {
+      "order": 4,
+      "type": "Cavalry",
+      "attack": 3,
+      "hits": 3,
+      "size": 3,
+      "points": 60,
+      "max": 4
+    },
+    "Spiders": {
+      "order": 5,
+      "type": "Monster",
+      "attack": 3,
+      "hits": 3,
+      "armour": "6+",
+      "size": 3,
+      "points": 70,
+      "max": 1
+    },
+    "Gigantic Bats": {
+      "order": 6,
+      "type": "Monster",
+      "attack": 2,
+      "hits": 3,
+      "size": 3,
+      "points": 60,
+      "max": 1
+    },
+    "Storm Giant": {
+      "order": 7,
+      "type": "Monster",
+      "attack": 8,
+      "hits": 8,
+      "armour": "5+",
+      "size": 1,
+      "points": 150,
+      "max": 1
+    },
+    "Dragon": {
+      "order": 8,
+      "type": "Monster",
+      "attack": "6/3",
+      "hits": 6,
+      "armour": "4+",
+      "size": 1,
+      "points": 350,
+      "max": 1,
+      "specialRules": [
+        "Smaug"
+      ]
+    },
+    "Bolg": {
+      "order": 9,
+      "type": "Hero",
+      "attack": "+2",
+      "command": 9,
+      "size": 1,
+      "points": 80,
+      "armyMin": 1,
+      "armyMax": 1,
+      "upgrades": [
+        "General"
+      ]
+    },
+    "Goblin Chieftain": {
+      "order": 10,
+      "type": "Hero",
+      "attack": "+1",
+      "command": 8,
+      "size": 1,
+      "points": 80,
+      "max": 3,
+      "upgrades": [
+        "General"
+      ]
+    },
+    "Goblin Shaman": {
+      "order": 11,
+      "type": "Wizard",
+      "attack": "+0",
+      "command": 7,
+      "size": 1,
+      "points": 45,
+      "max": 1,
+      "specialRules": [
+        "Shaman"
+      ],
+      "upgrades": [
+        "General"
+      ]
+    }
+  },
+  "upgrades": {
+    "General": {
+      "order": 0,
+      "type": "General",
+      "attack": "+1",
+      "command": "+1",
+      "points": "+0",
+      "armyMin": 1,
+      "armyMax": 1
+    }
+  },
+  "magic": true,
+  "specialRules": {
+    "Goblins": {
+      "order": 1,
+      "text": [
+        "Goblin infantry and cavalry units fight with a variety of weapons including some bows and thrown weapons such as spears and axes. To represent this, Goblins and Wolf Rider units are allowed to shoot as if they had bows but their range is reduced to 15cm."
+      ]
+    },
+    "Hill Trolls": {
+      "order": 2,
+      "text": [
+        "Hill Trolls and witless creatures that find it hard to remember orders, let alone obey them. To represent this, any Command penalty applied for distance between the character and Hill Troll unit is always doubled."
+      ]
+    },
+    "Wolf Riders": {
+      "order": 3,
+      "text": [
+        "Wolf Riders are able to see all the way round — not just to their front. This enables Wolf Riders to shoot in any direction, or to charge or evade from the closest enemy within 20cm regardless of their relative position."
+      ]
+    },
+    "Spiders": {
+      "order": 4,
+      "text": [
+        "Spiders of Mirkwood can move and see through woods and forest as if the terrain were not there. Spider stands that are wholly or partially within woods can shoot at troops charging their unit. This represents the sticky webs they have spun from tree to tree.  Web ‘shots’ are resolved as one shooting attack for each of the unit’s stands that is within the wood. Spiders do not need to be able to see their attackers to use this ability – so enemies will encounter webs even if they charge from behind. Note that Spiders cannot shoot otherwise."
+      ]
+    },
+    "Gigantic Bats": {
+      "order": 5,
+      "text": [
+        "Gigantic Bats can fly."
+      ]
+    },
+    "Storm Giant": {
+      "order": 6,
+      "text": [
+        "Storm Giants are rather big and stupid. All Storm Giants have to be given separate orders – they cannot be brigaded with other units, not even with other Storm Giants. If you attempt to give and order to a Storm Giant and fail then you must take a Giant Goes Wild test to see what he does. Ignore potential blunders – these are taken into account by the test.",
+        "",
+        "Storm Giants cause terror in its enemies.",
+        "",
+        "Storm Giants are allowed to charge fortified enemies. They are not tall enough to move over high linear obstacles or city walls – and so cannot pursue retreating fortified enemies.",
+        "",
+        "Storm Giants have a great many hits (8) and we must consider the possibility of hurting the Giant and reducing its effectiveness. Therefore, if a Storm Giant has suffered 4-7 hits by the end of the Shooting phase or Combat phase it is deemed to have been badly hurt. Once badly hurt, the Giant’s outstanding hits are discounted and his Hits and Attacks are halved for the rest of the battle (to 4 Hits and 4 Attacks).",
+        "",
+        "__Giant Goes Wild Chart__",
+        "",
+        "|||",
+        "-|-",
+        "_D6_|_On no! What's he doing now!_",
+        "1|The Storm Giant will neither move nor fight this turn but simply stands rooted to the spot looking bewildered.",
+        "2|Move the Storm Giant directly towards the nearest table edge. If he moves into another unit he will attack it regardless of which side it is on. If victorious in combat the Storm Giant will hold his ground.",
+        "3|The Storm Giant picks up a rock, tree, abandoned cart, small building or whatever comes to hand and throws it at the closest unit he can see – friend or foe. The object travels 5×D6cm and, if it travels far enough to hit its target, strikes with 3 Attacks worked out in the usual way.",
+        "4|The Storm Giant moves straight forward at full pace in the direction he is facing. If he reaches an enemy unit he will charge and fight as normal. If he reaches a friendly unit he will walk straight through it. A friendly unit that has been walked through is immediately confused – but ceases to be confused at the end of the Command phase along with other confused units.",
+        "5|The Storm Giant moves as fast as he can towards the nearest enemy unit. If he reaches the enemy unit he will attack as normal. If friends are in the way he will walk through them causing confusion as described above.",
+        "6|The Storm Giant gives a mighty bellow and rushes straight at the nearest enemy unit he can see. Move the Storm Giant at double his normal full pace. If friends are in the way he will walk through them causing confusion as described above. If he reaches an enemy unit, he fights by furiously jumping up and down on the foe, crazily doubling his Attack value in the first round of combat."
+      ]
+    },
+    "Smaug": {
+      "order": 7,
+      "text": [
+        "Smaug is the greatest of all living Dragons and an intelligent and cunning wyrm.",
+        "",
+        "Smaug can fly, breath fire, and causes terror.",
+        "",
+        "Dragons are large monsters and Smaug has a great many hits (6) to reflect this. We must consider the possibility of hurting a Dragon and reducing its effectiveness in subsequent turns. Therefore, if Smaug has suffered 3-5 hits by the end of the Shooting phase or Combat phase he is deemed to have been badly hurt. Once badly hurt, all Smaug’s outstanding hits are discounted and his Hits and Attacks are halved for the rest of the battle (to 3/3 Hits and 3 Attacks).",
+        "",
+        "Smaug has a special shooting attach – he can breath fire. The fire breath has a range of 20cm. Fire can be directed at one enemy unit in the normal manner and has three attacks worked out in the same way as bowfire and other shooting."
+      ]
+    },
+    "Goblin Shaman": {
+      "order": 8,
+      "text": [
+        "Goblin Shamans are powerful creatures – so the Evil army can normally include no more than one Shaman. However, the army can include more Shamans if these are substituted for Chieftain choices. For example, a 2,000 point army could have two Shamans and five Chieftains, rather than one Shaman and six Chieftains. However, the army may never include more Shamans than the one per 1,000 point limit indicated."
+      ]
+    },
+    "General": {
+      "order": 9,
+      "text": [
+        "One character must be nominated as the army’s General. This character has an extra bonus Attack and a Command value of +1 on normal."
+      ]
+    }
+  },
+  "spells": [
+    {
+      "name": "Foul Frenzy",
+      "roll": 4,
+      "range": "30cm",
+      "text": [
+        "*The Goblin hordes are driven into a foul frenzy of bloodlust by the intoxicating powers of dark magic.*",
+        "",
+        "This spell can be cast on a friendly Goblin infantry or Wolf Rider unit within 30cm regardless of whether the Shaman has line of sight or not. The spell can only be cast at a unit that is engaged in combat.",
+        "",
+        "Every stand in the unit, including a character that is fighting with the unit, adds +1 to its Attacks value during the first round of the following Combat phase."
+      ]
+    },
+    {
+      "name": "Dark Swarm",
+      "roll": 5,
+      "range": "30cm",
+      "text": [
+        "*A swarm of dreaded bloodsucking bats and nameless dark horrors swirls about the foe and feats upon the wounded.*",
+        "",
+        "This spell can be cast on any enemy unit within range regardless of whether the Shaman has line of sight or not. The spell can be cast at a target engaged in combat or a target that is not engaged in combat – it makes no difference.",
+        "",
+        "The *Dark Swarm* is worked out exactly like three ordinary shooting attacks. If the target is not engaged in combat, hits inflicted by a *Dark Swarm* are counted towards drive backs just like ordinary shooting. If the target is engaged in combat, hits inflicted by a *Dark Swarm* are carried over into the Combat phase and count towards the combat result in the first round."
+      ]
+    },
+    {
+      "name": "Faster You Dogs",
+      "roll": 5,
+      "range": "60cm",
+      "text": [
+        "*The Shaman’s frantic gibbering forces the cowardly Goblin ranks forwards against their will.*",
+        "",
+        "This spell can be cast on a friendly Goblin infantry or Wolf Rider unit within range regardless of whether the Shaman has line of sight or not. The spell can only be cast at a unit that is not engaged in combat.",
+        "",
+        "If the spell is cast upon a unit, it can move immediately just as if it had received an order in the Command phase. Note that the spell affects only a single unit – it is not a brigade order – and any characters with the unit will not move with it."
+      ]
+    }
+  ]
+}

--- a/public/json/warmaster-the-battle-of-five-armies/good.json
+++ b/public/json/warmaster-the-battle-of-five-armies/good.json
@@ -1,0 +1,278 @@
+{
+  "name": "Good Army",
+  "version": "Warmaster The Battle of Five Armies",
+  "group": 0,
+  "order": 0,
+  "units": {
+    "Elves": {
+      "order": 0,
+      "type": "Infantry",
+      "attack": 3,
+      "hits": 3,
+      "armour": "6+",
+      "size": 3,
+      "points": 50
+    },
+    "Elf Archers": {
+      "order": 1,
+      "type": "Infantry",
+      "attack": "2/1",
+      "range": "30cm",
+      "hits": 3,
+      "armour": "0",
+      "size": 3,
+      "points": 45,
+      "min": 2,
+      "max": 4
+    },
+    "Elf Cavalry": {
+      "order": 2,
+      "type": "Cavalry",
+      "attack": 3,
+      "hits": 3,
+      "armour": "6+",
+      "size": 3,
+      "points": 80,
+      "max": 2
+    },
+    "Dwarfs": {
+      "order": 3,
+      "type": "Infantry",
+      "attack": 3,
+      "hits": 4,
+      "armour": "4+",
+      "size": 3,
+      "points": 110,
+      "min": 1
+    },
+    "Dwarf Archers": {
+      "order": 4,
+      "type": "Infantry",
+      "attack": "2/1",
+      "range": "30cm",
+      "hits": 4,
+      "armour": "5+",
+      "size": 3,
+      "points": 80,
+      "max": 1
+    },
+    "Men": {
+      "order": 5,
+      "type": "Infantry",
+      "attack": 3,
+      "hits": 3,
+      "armour": "6+",
+      "size": 3,
+      "points": 45,
+      "min": 1
+    },
+    "Men Archers": {
+      "order": 6,
+      "type": "Infantry",
+      "attack": "2/1",
+      "range": "30cm",
+      "hits": 3,
+      "armour": "0",
+      "size": 3,
+      "points": 30,
+      "max": 2
+    },
+    "Eagles": {
+      "order": 7,
+      "type": "Monster",
+      "attack": 2,
+      "hits": 3,
+      "armour": "6+",
+      "size": 3,
+      "points": 70,
+      "max": 1
+    },
+    "Giant Bear": {
+      "order": 8,
+      "type": "Monster",
+      "attack": 6,
+      "hits": 4,
+      "armour": "4+",
+      "size": 1,
+      "points": 125,
+      "max": 1
+    },
+    "Wizard": {
+      "order": 9,
+      "type": "Wizard",
+      "attack": "+1",
+      "command": 8,
+      "size": 1,
+      "points": 120,
+      "armyMax": 1,
+      "upgrades": [
+        "General"
+      ]
+    },
+    "Hero": {
+      "order": 10,
+      "type": "Hero",
+      "attack": "+2",
+      "command": 8,
+      "size": 1,
+      "points": 80,
+      "max": 2,
+      "upgrades": [
+        "General"
+      ]
+    }
+  },
+  "upgrades": {
+    "General": {
+      "order": 0,
+      "type": "General",
+      "attack": "+1",
+      "command": "+1",
+      "points": "+0",
+      "armyMin": 1,
+      "armyMax": 1
+    }
+  },
+  "magic": true,
+  "specialRules": {
+    "Elf Archers": {
+      "order": 1,
+      "text": [
+        "Elves have incredibly quick reactions making them exceptionally potent warriors. To represent this, Elves add +1 to their dice when rolling Attacks for shooting and in the first round of each combat engagement, including combats resulting from an advance."
+      ]
+    },
+    "Eagles": {
+      "order": 2,
+      "text": [
+        "Eagles can fly."
+      ]
+    },
+    "Giant Bear": {
+      "order": 3,
+      "text": [
+        "Giant Bears cause terror."
+      ]
+    },
+    "General": {
+      "order": 4,
+      "text": [
+        "One character must be nominated as the army’s General. This character has an extra bonus Attack and a Command value of +1 on normal."
+      ]
+    }
+  },
+  "spells": [
+    {
+      "name": "Fireball",
+      "roll": 5,
+      "range": "30cm",
+      "text": [
+        "*True wizard only*",
+        "",
+        "*The Wizard hurls a ball of fire straight at his foes.*",
+        "",
+        "The Wizard must have a clear line of sight to cast this spell. The spell cannot be directed at a unit that is engaged in combat.",
+        "",
+        "The *Fireball* is worked out exactly like three ordinary shooting attacks except that all targets count as having no armour – armour has no effect against a *Fireball*. Hits inflicted by a *Fireball* will cause drive backs just like ordinary shooting."
+      ]
+    },
+    {
+      "name": "Command",
+      "roll": 5,
+      "range": "30cm",
+      "text": [
+        "*True wizard only*",
+        "",
+        "*The Wizard’s steady voice directs troops above the tumult of war.*",
+        "",
+        "This spell can be cast on any friendly unit within range regardless of whether the Wizard has line of sight or not. It cannot be cast on a unit that is engaged in combat.",
+        "",
+        "Once this spell is cast upon the unit, it can move immediately just as if it had received an order in the Command phase. Note that the spell affects only a single unit (it is not a brigade order) and any characters with the unit will not move with it."
+      ]
+    },
+    {
+      "name": "Blast",
+      "roll": 5,
+      "range": "Combat only",
+      "text": [
+        "*True wizard only*",
+        "",
+        "*A blast of sorcerous energy strikes the Wizard’s foes.*",
+        "",
+        "The spell can only be cast if the Wizard has joined a friendly unit that is engaged in combat. The spell can be cast upon any one enemy unit that the friendly unit is touching.",
+        "",
+        "The *Blast* is worked out exactly like three ordinary shooting attacks except that all targets count as having no armour – armour has no effect against a *Blast*. Hits inflicted by a *Blast* are carried over into the Combat phase and counted towards the combat results of the first round."
+      ]
+    },
+    {
+      "name": "Confound",
+      "roll": 6,
+      "range": "60cm",
+      "text": [
+        "*True wizard only*",
+        "",
+        "*By whispering magical words of doubt and dissension amongst the target, the Wizard succeeds in enticing the foe into squabbling amongst themselves.*",
+        "",
+        "This spell can be cast upon any enemy unit within range regardless of whether the Wizard can see it or not.",
+        "",
+        "The enemy unit becomes confused as described in the Confusion rules."
+      ]
+    },
+
+    {
+      "name": "Back Vile Creatures",
+      "roll": 4,
+      "range": "30cm",
+      "text": [
+        "*Elven mage only*",
+        "",
+        "*The foe quails before the might of the Elven host – scattering and listing their will to fight.*",
+        "",
+        "The Wizard must have a clear line of sight to his target to cast this spell. The spell cannot be directed at a unit engaged in combat.",
+        "",
+        "The target unit is not harmed as a result, but is driven back by 3d6cm at the end of the Shooting phase as if it had taken three shooting hits from the Elven Mage. If the unit also suffers hits from shooting then the Drive Back roll is combined adding three dice for the effect of the spell."
+      ]
+    },
+    {
+      "name": "Terrifying Radiance",
+      "roll": 5,
+      "range": "30cm",
+      "text": [
+        "*Elven mage only*",
+        "",
+        "*The enemy are confounded by the terrifying radiance of the Elven warriors, their weapons slacken in their grasp and they whimper pathetically.*",
+        "",
+        "This spell can be cast on a friendly unit within range regardless of whether the Wizard has a line of sight or not. The spell can only be cast on a unit that is engaged in combat.",
+        "",
+        "If the spell is cast upon a unit, it causes terror for the rest of the following Combat phase."
+      ]
+    },
+    {
+      "name": "Shoot!",
+      "roll": 5,
+      "range": "30cm",
+      "text": [
+        "*Elven mage only*",
+        "",
+        "*Elven archers redouble their efforts as rigor and determination steel their worn limbs.*",
+        "",
+        "This spell can be cast upon a unit of Elven archers within range regardless of whether the Wizard has a line of sight or not. The Wizard must have a clear line of sight to his target to cast this spell. The spell cannot be directed at a unit engaged in combat.",
+        "",
+        "The unit can shoot immediately regardless of whether it has already shot that turn. In effect, the unit can shoot twice this turn."
+      ]
+    },
+    {
+      "name": "Conceal",
+      "roll": 6,
+      "range": "30cm",
+      "text": [
+        "*Elven mage only*",
+        "",
+        "*Mystical energies enshroud friends, concealing them amongst the shadows.*",
+        "",
+        "This spell can be cast upon a unit of Elves within range regardless of whether the Wizard has a line of sight or not. This spell cannot be cast on a unit that is engaged in combat.",
+        "",
+        "The unit immediately increases its armour roll by 1 (ie, if 6+ it becomes 5+). If the target has no Armour value it now has a value of 6+. This lasts for the duration of the enemy’s following turn and ends at the start of the Good player’s following turn."
+      ]
+    }
+  ]
+}

--- a/src/json/magic-items/Warmaster The Battle of Five Armies.json
+++ b/src/json/magic-items/Warmaster The Battle of Five Armies.json
@@ -1,0 +1,122 @@
+{
+  "upgrades": {
+    "Heirloom of Kings": {
+      "order": "A",
+      "type": "Device of Power",
+      "points": "+30",
+      "armyMax": 1,
+      "text": [
+        "The character can reroll a failed command once in a battle. If the re-roll is successful, the command is issued and the character can continue to issue commands in the usual way. If the re-roll fails, the command is not issued. If the re-roll fails and scores equal to or more than the first roll, the character suffers a -1 Command penalty for the rest of the battle as his warriors lose faith in him."
+      ]
+    },
+    "Staff of Sorcery": {
+      "order": "B",
+      "type": "Device of Power",
+      "points": "+30",
+      "armyMax": 1,
+      "text": [
+        "Only a wizard can carry a Staff of Sorcery. A character that has a Staff of Sorcery can attempt to dispel one spell cast by the enemy each turn. Once the spell has been cast, but before working out its effects, the Wizard can attempt to dispel it. Roll a d6 - a score of 6 indicates the spell has been dispelled, otherwise the spell is not dispelled and takes effect as normal.  However - if the player wishes, he can count the failed dispel attempt as successful but the Staff of Sorcery is then exhausted and cannot be used for the rest of the battle. A dispelled spell simply doesn't work - just as if the caster had failed the initial casting roll."
+      ]
+    },
+    "Sorcerous Weapon": {
+      "order": "C",
+      "type": "Magic Weapon",
+      "points": "+20",
+      "armyMax": 1,
+      "text": [
+        "The character adds +1 to his Attack bonus. This bonus applies for the entire battle. For example, if the character has a +2 attacks bonus he has a +2 attacks bonus if he carries a Sorcerous Weapon."
+      ]
+    },
+    "Sorcerous Armour": {
+      "order": "D",
+      "type": "Device of Power",
+      "points": "+10",
+      "armyMax": 1,
+      "text": [
+        "When the character fights in combat, the unit he is with can re-roll one failed Armour roll in each round of combat. This applies throughout the battle - the unit can re-roll one failed Armour roll each round. If the unit the character has joined as no Armour value then the unit takes a single roll each round with a value of 6+."
+      ]
+    },
+    "Staff of Power": {
+      "order": "E",
+      "type": "Device of Power",
+      "points": "+10",
+      "armyMax": 1,
+      "text": [
+        "Only a wizard can carry a staff of power. A character that has a staff of power can add +1 to his dice roll to cast a spell. The bonus can only be used once in the game - but the player can decide to use the staff after the dice has been rolled to cast a spell. For example, the player requires a roll of 4+ to cast a spell, he rolls a 3 but uses the staff to boost the score to 4 and cast the spell."
+      ]
+    },
+    "Ring of Invisibility": {
+      "order": "F",
+      "type": "Device of Power",
+      "points": "+10",
+      "armyMax": 1,
+      "text": [
+        "Many rings were made by the Elves in times past and a few still survive to this day - some are mere trinkets and others dangerous weapons for good or evil. A character with a Ring of Invisibility can use it to disappear and reappear elsewhere, thereby escaping from danger. The ring can be used at any time, even in the opponent’s turn, but only once in any battle. The character can immediately move from wherever he is to anywhere else on the battlefield. Even out of or into combat if he wishes. The character can even move through enemy units - invisibility allows him to sneak his way past foes without being spotted."
+      ]
+    },
+    "Enchanted Weapon": {
+      "order": "G",
+      "type": "Magic Weapon",
+      "points": "+10",
+      "armyMax": 1,
+      "text": [
+        "The first time the character fights in combat he adds an extra +1 to his attack bonus. This extra bonus only works in the first Combat phase - so it applies for each round of the combat engagement and during any further engagements wrestling from an advance. For example, a character with 2 attack value will have 3 attack value throughout the first Combat phase of fighting, and 2 attack value in subsequent turns."
+      ]
+    },
+    "Mystical Weapon": {
+      "order": "H",
+      "type": "Magic Weapon",
+      "points": "+5",
+      "armyMax": 1,
+      "text": [
+        "The first time the character fights in combat add an extra +1 to his attack bonus. This extra bonus only works in the first Combat round- so it applies only once in the entire game. For example, a character with 2 attack value will have 3 attack value in the first combat of the first Combat phase of fighting, and 2 attack value in subsequent turns."
+      ]
+    },
+    "Enchanted Armour": {
+      "order": "I",
+      "type": "Device of Power",
+      "points": "+5",
+      "armyMax": 1,
+      "text": [
+        "When the character fights in combat, the unit he is with can re-roll one failed armour roll in the first round that a hit is scored. This applies only once in the entire game and automatically applies the first time such a unit takes a hit. If the unit the character has joined has no Armour value then the unit takes a single roll with a value of 6+."
+      ]
+    }
+  },
+  "upgradeConstraints": [
+    {
+      "unitType": [
+        "General",
+        "Hero",
+        "Wizard"
+      ],
+      "upgrades": [
+        "Heirloom of Kings",
+        "Sorcerous Weapon",
+        "Sorcerous Armour",
+        "Ring of Invisibility",
+        "Enchanted Weapon",
+        "Mystical Weapon",
+        "Enchanted Armour"
+      ],
+      "magic": true
+    },
+    {
+      "unitType": [
+        "General"
+      ],
+      "upgrades": [
+      ],
+      "magic": true
+    },
+    {
+      "unitType": [
+        "Wizard"
+      ],
+      "upgrades": [
+        "Staff of Sorcery",
+        "Staff of Power"
+      ],
+      "magic": true
+    }
+  ]
+}

--- a/src/utils/version-key.js
+++ b/src/utils/version-key.js
@@ -6,4 +6,5 @@ export default {
   'Warmaster Ancient Armies': 'Warmaster Ancients',
   'Warmaster Medieval Armies': 'Warmaster Medieval Armies',
   'Warmaster Evolution': 'Warmaster Evolution',
+  'Warmaster The Battle of Five Armies': 'Warmaster The Battle of Five Armies',
 };

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -42,6 +42,9 @@
       <a target="_blank" title="Warmaster Evolution Règles" href="/pdfs/WME_Regles_v4-0-0.pdf"><span>Warmaster Evolution Règles</span></a>
       <a target="_blank" title="Warmaster Evolution Armées" href="/pdfs/WME_Armees_v2.42_beta.pdf"><span>Warmaster Evolution Armées</span></a>
     </ArmyListAccordion>
+
+    <ArmyListAccordion :title="'Warmaster The Battle of Five Armies'">
+    </ArmyListAccordion>
   </main>
 </template>
 


### PR DESCRIPTION
This is the "Advanced Rules" lists, with the exception that including a second (or more) Goblin Shaman in place of a Chieftain is not implemented.

Wizards or Heroes can be Generals, so this is done using an upgrade.

Links to the rules are [available here](https://www.reddit.com/r/warmaster/comments/tblgxh/battle_of_five_armies/).

It's unclear to me whether Elves (infantry) are supposed to have the "Elves" special ability, marked with * on the Elven Archers.  I have changed the name of the ability to "Elf Archers" as it would otherwise apply automatically to the "Elves".