### PR TITLE
Fix hits of Cathay Maneaters, spelling of Teppo, order of Rhinox Riders.

### DIFF
--- a/public/json/the-battle-of-five-armies/evil.json
+++ b/public/json/the-battle-of-five-armies/evil.json
@@ -97,21 +97,8 @@
         "Smaug"
       ]
     },
-    "Bolg": {
-      "order": 9,
-      "type": "Hero",
-      "attack": "+2",
-      "command": 9,
-      "size": 1,
-      "points": 80,
-      "armyMin": 1,
-      "armyMax": 1,
-      "upgrades": [
-        "General"
-      ]
-    },
     "Goblin Chieftain": {
-      "order": 10,
+      "order": 9,
       "type": "Hero",
       "attack": "+1",
       "command": 8,
@@ -119,17 +106,18 @@
       "points": 80,
       "max": 3,
       "upgrades": [
-        "General"
+        "General",
+        "Shaman"
       ]
     },
     "Goblin Shaman": {
-      "order": 11,
+      "order": 10,
       "type": "Wizard",
       "attack": "+0",
       "command": 7,
       "size": 1,
       "points": 45,
-      "max": 1,
+      "armyMax": 1,
       "specialRules": [
         "Shaman"
       ],
@@ -147,6 +135,14 @@
       "points": "+0",
       "armyMin": 1,
       "armyMax": 1
+    },
+    "Shaman": {
+      "order": 1,
+      "type": "Special",
+      "attack": "+0",
+      "command": "7",
+      "points": "-25",
+      "max": "elite"
     }
   },
   "magic": true,

--- a/public/json/the-battle-of-five-armies/good.json
+++ b/public/json/the-battle-of-five-armies/good.json
@@ -19,11 +19,13 @@
       "attack": "2/1",
       "range": "30cm",
       "hits": 3,
-      "armour": "0",
       "size": 3,
       "points": 45,
       "min": 2,
-      "max": 4
+      "max": 4,
+      "specialRules": [
+        "Elves"
+      ]
     },
     "Elf Cavalry": {
       "order": 2,
@@ -33,7 +35,10 @@
       "armour": "6+",
       "size": 3,
       "points": 80,
-      "max": 2
+      "max": 2,
+      "specialRules": [
+        "Elves"
+      ]
     },
     "Dwarfs": {
       "order": 3,
@@ -72,7 +77,6 @@
       "attack": "2/1",
       "range": "30cm",
       "hits": 3,
-      "armour": "0",
       "size": 3,
       "points": 30,
       "max": 2
@@ -135,7 +139,7 @@
   },
   "magic": true,
   "specialRules": {
-    "Elf Archers": {
+    "Elves": {
       "order": 1,
       "text": [
         "Elves have incredibly quick reactions making them exceptionally potent warriors. To represent this, Elves add +1 to their dice when rolling Attacks for shooting and in the first round of each combat engagement, including combats resulting from an advance."

--- a/public/json/warmaster-revolution/albion.json
+++ b/public/json/warmaster-revolution/albion.json
@@ -1,7 +1,7 @@
 {
   "name": "Albion",
   "version": "Warmaster Revolution",
-  "group": 2,
+  "group": 0,
   "order": 0,
   "units": {
     "Warriors": {

--- a/public/json/warmaster-revolution/araby.json
+++ b/public/json/warmaster-revolution/araby.json
@@ -1,8 +1,8 @@
 {
   "name": "Araby",
   "version": "Warmaster Revolution",
-  "group": 1,
-  "order": 4,
+  "group": 0,
+  "order": 1,
   "units": {
     "Spearmen": {
       "order": 0,

--- a/public/json/warmaster-revolution/beastmen.json
+++ b/public/json/warmaster-revolution/beastmen.json
@@ -1,8 +1,8 @@
 {
   "name": "Beastmen",
   "version": "Warmaster Revolution",
-  "group": 2,
-  "order": 5,
+  "group": 0,
+  "order": 2,
   "units": {
     "Gor": {
       "order": 0,

--- a/public/json/warmaster-revolution/bretonnia.json
+++ b/public/json/warmaster-revolution/bretonnia.json
@@ -1,8 +1,8 @@
 {
   "name": "Bretonnia",
   "version": "Warmaster Revolution",
-  "group": 1,
-  "order": 0,
+  "group": 0,
+  "order": 3,
   "units": {
     "Bowmen": {
       "order": 0,

--- a/public/json/warmaster-revolution/cathay.json
+++ b/public/json/warmaster-revolution/cathay.json
@@ -47,6 +47,7 @@
       "order": 4,
       "type": "Infantry",
       "attack": 4,
+      "hits": 4,
       "range": 4,
       "armour": "4+",
       "size": 3,

--- a/public/json/warmaster-revolution/cathay.json
+++ b/public/json/warmaster-revolution/cathay.json
@@ -1,8 +1,8 @@
 {
   "name": "Cathay",
   "version": "Warmaster Revolution",
-  "group": 2,
-  "order": 7,
+  "group": 0,
+  "order": 4,
   "units": {
     "Bannermen": {
       "order": 0,

--- a/public/json/warmaster-revolution/chaos-dwarfs.json
+++ b/public/json/warmaster-revolution/chaos-dwarfs.json
@@ -177,7 +177,7 @@
       "type": "Monstrous Mount",
       "attack": "+1",
       "points": "+35",
-      "max": 1
+      "armyMax": 1
     },
     "Sorcerer Lord": {
       "order": 2,

--- a/public/json/warmaster-revolution/chaos-dwarfs.json
+++ b/public/json/warmaster-revolution/chaos-dwarfs.json
@@ -1,8 +1,8 @@
 {
   "name": "Chaos Dwarfs",
   "version": "Warmaster Revolution",
-  "group": 2,
-  "order": 3,
+  "group": 0,
+  "order": 5,
   "units": {
     "Chaos Dwarfs": {
       "order": 0,

--- a/public/json/warmaster-revolution/chaos.json
+++ b/public/json/warmaster-revolution/chaos.json
@@ -2,7 +2,7 @@
   "name": "Chaos",
   "version": "Warmaster Revolution",
   "group": 0,
-  "order": 2,
+  "order": 6,
   "units": {
     "Chaos Warriors": {
       "order": 0,

--- a/public/json/warmaster-revolution/daemons.json
+++ b/public/json/warmaster-revolution/daemons.json
@@ -1,8 +1,8 @@
 {
   "name": "Daemons",
   "version": "Warmaster Revolution",
-  "group": 1,
-  "order": 3,
+  "group": 0,
+  "order": 7,
   "units": {
     "Daemon Hordes": {
       "order": 0,

--- a/public/json/warmaster-revolution/dark-elves.json
+++ b/public/json/warmaster-revolution/dark-elves.json
@@ -2,7 +2,7 @@
   "name": "Dark Elves",
   "version": "Warmaster Revolution",
   "group": 1,
-  "order": 2,
+  "order": 0,
   "units": {
     "Spearmen": {
       "order": 0,

--- a/public/json/warmaster-revolution/dogs-of-war.json
+++ b/public/json/warmaster-revolution/dogs-of-war.json
@@ -2,7 +2,7 @@
   "name": "Dogs of War",
   "version": "Warmaster Revolution",
   "group": 1,
-  "order": 6,
+  "order": 1,
   "units": {
     "Pikemen": {
       "order": 0,

--- a/public/json/warmaster-revolution/dwarfs.json
+++ b/public/json/warmaster-revolution/dwarfs.json
@@ -1,8 +1,8 @@
 {
   "name": "Dwarfs",
   "version": "Warmaster Revolution",
-  "group": 0,
-  "order": 5,
+  "group": 1,
+  "order": 2,
   "units": {
     "Warriors": {
       "order": 0,

--- a/public/json/warmaster-revolution/empire.json
+++ b/public/json/warmaster-revolution/empire.json
@@ -1,8 +1,8 @@
 {
   "name": "Empire",
   "version": "Warmaster Revolution",
-  "group": 0,
-  "order": 0,
+  "group": 1,
+  "order": 3,
   "units": {
     "Halberdiers": {
       "order": 0,

--- a/public/json/warmaster-revolution/goblin.json
+++ b/public/json/warmaster-revolution/goblin.json
@@ -1,8 +1,8 @@
 {
   "name": "Goblin",
   "version": "Warmaster Revolution",
-  "group": 2,
-  "order": 1,
+  "group": 1,
+  "order": 4,
   "units": {
     "Goblins": {
       "order": 0,

--- a/public/json/warmaster-revolution/high-elves.json
+++ b/public/json/warmaster-revolution/high-elves.json
@@ -1,8 +1,8 @@
 {
   "name": "High Elves",
   "version": "Warmaster Revolution",
-  "group": 0,
-  "order": 4,
+  "group": 1,
+  "order": 5,
   "units": {
     "Spearmen": {
       "order": 0,

--- a/public/json/warmaster-revolution/kislev.json
+++ b/public/json/warmaster-revolution/kislev.json
@@ -2,7 +2,7 @@
   "name": "Kislev",
   "version": "Warmaster Revolution",
   "group": 1,
-  "order": 1,
+  "order": 6,
   "units": {
     "Winged Lancers": {
       "order": 0,

--- a/public/json/warmaster-revolution/lizardmen.json
+++ b/public/json/warmaster-revolution/lizardmen.json
@@ -1,7 +1,7 @@
 {
   "name": "Lizardmen",
   "version": "Warmaster Revolution",
-  "group": 0,
+  "group": 1,
   "order": 7,
   "units": {
     "Skinks": {

--- a/public/json/warmaster-revolution/nippon.json
+++ b/public/json/warmaster-revolution/nippon.json
@@ -183,7 +183,7 @@
     "Ashigaru Teppo": {
       "order": 1,
       "text": [
-        "These units use black powder handguns. Their projectiles can pierce armour far easier than an arrow. Therefore, units hit by Ashigaru Tepo get a -1 penalty for their armour rolls."
+        "These units use black powder handguns. Their projectiles can pierce armour far easier than an arrow. Therefore, units hit by Ashigaru Teppo get a -1 penalty for their armour rolls."
       ]
     },
     "Bushido": {

--- a/public/json/warmaster-revolution/nippon.json
+++ b/public/json/warmaster-revolution/nippon.json
@@ -2,7 +2,7 @@
   "name": "Nippon",
   "version": "Warmaster Revolution",
   "group": 2,
-  "order": 8,
+  "order": 0,
   "units": {
     "Ashigaru": {
       "order": 0,

--- a/public/json/warmaster-revolution/norse.json
+++ b/public/json/warmaster-revolution/norse.json
@@ -2,7 +2,7 @@
   "name": "Norse",
   "version": "Warmaster Revolution",
   "group": 2,
-  "order": 6,
+  "order": 1,
   "units": {
     "Bondsmen": {
       "order": 0,

--- a/public/json/warmaster-revolution/ogre-kingdoms.json
+++ b/public/json/warmaster-revolution/ogre-kingdoms.json
@@ -54,24 +54,24 @@
       "points": 30,
       "max": 4
     },
-    "Rhinox Riders": {
-      "order": 5,
-      "type": "Cavalry",
-      "attack": 5,
-      "hits": 4,
-      "armour": "5+",
-      "size": 3,
-      "points": 200,
-      "max": 1
-    },
     "Gorgers": {
-      "order": 6,
+      "order": 5,
       "type": "Infantry",
       "attack": 5,
       "hits": 3,
       "armour": "5+",
       "size": 3,
       "points": 110,
+      "max": 1
+    },
+    "Rhinox Riders": {
+      "order": 6,
+      "type": "Cavalry",
+      "attack": 5,
+      "hits": 4,
+      "armour": "5+",
+      "size": 3,
+      "points": 200,
       "max": 1
     },
     "Sabretusks": {
@@ -183,14 +183,8 @@
         "Unit is allowed to shoot as if it had bows but its range is reduced to 15cm. A Gnoblar stand cannot be supported by other kinds of infantry - only by other Gnoblar stands. Note, however, that Gnoblars can support other kinds of infantry as normal. Gnoblars cannot be given magic items. Characters cannot join Gnoblar units."
       ]
     },
-    "Rhinox Riders": {
-      "order": 5,
-      "text": [
-        "Units of Rhinox Riders are unaffected by terror. Rhinox Riders receive +1 Attack when charging against an enemy in open in the same way as chariots and monsters."
-      ]
-    },
     "Gorgers": {
-      "order": 6,
+      "order": 5,
       "text": [
         "When trying to issue an order to a unit of Gorgers or to a brigade that contains a unit of Gorgers, there is always a -1 Command penalty due their beastly and unruly nature.",
         "",
@@ -201,6 +195,12 @@
         "The nominated point must lie either on the table within dense terrain or on any base edge other than the enemy player‘s own table edge. If successful, place one stand on the nominated spot and arrange the rest of the unit into formation around it.",
         "",
         "The infiltrated unit cannot be placed so that it touches an enemy unit. Once deployed, orders can be given to the unit by the including same character that gave the infiltration order. The infiltrating unit is considered to have used its first order to deploy. If the infiltration order is failed the unit is not deployed and cannot infiltrate that turn, it can attempt to infiltrate in a subsequent turn at the same or a different place."
+      ]
+    },
+    "Rhinox Riders": {
+      "order": 6,
+      "text": [
+        "Units of Rhinox Riders are unaffected by terror. Rhinox Riders receive +1 Attack when charging against an enemy in open in the same way as chariots and monsters."
       ]
     },
     "Giant": {

--- a/public/json/warmaster-revolution/ogre-kingdoms.json
+++ b/public/json/warmaster-revolution/ogre-kingdoms.json
@@ -1,8 +1,8 @@
 {
   "name": "Ogre Kingdoms",
   "version": "Warmaster Revolution",
-  "group": 1,
-  "order": 7,
+  "group": 2,
+  "order": 2,
   "units": {
     "Bull Ogres": {
       "order": 0,

--- a/public/json/warmaster-revolution/orcs.json
+++ b/public/json/warmaster-revolution/orcs.json
@@ -1,7 +1,7 @@
 {
   "name": "Orcs",
   "version": "Warmaster Revolution",
-  "group": 0,
+  "group": 2,
   "order": 3,
   "units": {
     "Orc Warriors": {

--- a/public/json/warmaster-revolution/skaven.json
+++ b/public/json/warmaster-revolution/skaven.json
@@ -1,8 +1,8 @@
 {
   "name": "Skaven",
   "version": "Warmaster Revolution",
-  "group": 0,
-  "order": 6,
+  "group": 2,
+  "order": 4,
   "units": {
     "Clanrats": {
       "order": 0,

--- a/public/json/warmaster-revolution/tomb-kings.json
+++ b/public/json/warmaster-revolution/tomb-kings.json
@@ -1,8 +1,8 @@
 {
   "name": "Tomb Kings",
   "version": "Warmaster Revolution",
-  "group": 0,
-  "order": 1,
+  "group": 2,
+  "order": 5,
   "units": {
     "Skeletons": {
       "order": 0,

--- a/public/json/warmaster-revolution/vampire-counts.json
+++ b/public/json/warmaster-revolution/vampire-counts.json
@@ -1,8 +1,8 @@
 {
   "name": "Vampire Counts",
   "version": "Warmaster Revolution",
-  "group": 1,
-  "order": 5,
+  "group": 2,
+  "order": 6,
   "units": {
     "Skeletons": {
       "order": 0,

--- a/public/json/warmaster-revolution/witch-hunter.json
+++ b/public/json/warmaster-revolution/witch-hunter.json
@@ -2,7 +2,7 @@
   "name": "Witch Hunter",
   "version": "Warmaster Revolution",
   "group": 2,
-  "order": 2,
+  "order": 7,
   "units": {
     "Zealots": {
       "order": 0,

--- a/public/json/warmaster-revolution/wood-elves.json
+++ b/public/json/warmaster-revolution/wood-elves.json
@@ -203,7 +203,7 @@
       "type": "Special Mount",
       "attack": "+1",
       "points": "+15",
-      "max": 1
+      "armyMax": 1
     },
     "Warhawk": {
       "order": 2,

--- a/public/json/warmaster-revolution/wood-elves.json
+++ b/public/json/warmaster-revolution/wood-elves.json
@@ -2,7 +2,7 @@
   "name": "Wood Elves",
   "version": "Warmaster Revolution",
   "group": 2,
-  "order": 4,
+  "order": 8,
   "units": {
     "Glade Guard": {
       "order": 0,

--- a/src/App.vue
+++ b/src/App.vue
@@ -60,12 +60,6 @@ import { mapGetters } from 'vuex';
 
 import PrintItems from '@/components/Print/PrintItems';
 
-function removeHasFocusClass(element) {
-  Array.prototype.forEach.call(element.querySelectorAll('.hasFocus'), (element) => {
-    element.classList.remove('hasFocus');
-  });
-}
-
 export default {
   name: 'wm-selector',
   components: { PrintItems },
@@ -74,17 +68,6 @@ export default {
     local: window.location.hostname === 'localhost',
     version: process.env.VUE_APP_VERSION
   }),
-  mounted () {
-    document.addEventListener('focusin', (event) => {
-      if (event.target.closest('.hasFocus')) {
-        removeHasFocusClass(event.target.closest('.hasFocus'));
-      } else {
-        removeHasFocusClass(document);
-      }
-
-      event.target.classList.add('hasFocus');
-    });
-  }
 };
 </script>
 

--- a/src/components/Selector/UsedUnit.vue
+++ b/src/components/Selector/UsedUnit.vue
@@ -52,7 +52,6 @@ export default {
 
 <style lang="scss">
   .selector-view .used.unit {
-    &.hasFocus,
     &:hover {
       .upgrades {
         display: table;

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -173,6 +173,11 @@ export default {
   validate (context) {
     context.commit('CLEAR_ERRORS');
 
+    if (context.getters.pointsCost > 800 && context.getters.pointsCost < (1000 * context.getters.size)) {
+      context.commit('PUSH_ERROR', 'Limits calculated for a ' + context.getters.size + ',000 point army (' +
+        (1000 * context.getters.size - context.getters.pointsCost) + ' points remaining).');
+    }
+
     for (var unit in context.getters.units) {
       checkValidations(context, unit, context.getters.units[unit]);
     }
@@ -244,15 +249,15 @@ function checkValidations (context, id, item) {
   } else if (/^As /.test(item.min) &&
              item.number < requiredCount) {
     context.commit('PUSH_ERROR', 'Minimum of ' + requiredCount + ' ' + id + ' per ' + requiredCount + ' ' + requiredSentence + '.');
-  } else if (context.getters.pointsCost >= 1000 &&
+  } else if (context.getters.pointsCost > 800 && // Start the 1000-point army size at > 800 points
              item.number + homologousCount < item.min * context.getters.size) {
-    context.commit('PUSH_ERROR', 'Minimum of ' + (item.min * context.getters.size) + ' ' + id + ' per ' + context.getters.size + ',000 points.');
+    context.commit('PUSH_ERROR', 'Minimum of ' + (item.min * context.getters.size) + ' ' + id + ' in a ' + context.getters.size + ',000 point army.');
   }
 
   // max
   if (item.max === 'elite' &&
       item.number + homologousCount > context.getters.size - 1) {
-    context.commit('PUSH_ERROR', 'Maximum of ' + (context.getters.size - 1) + ' ' + id + ' per ' + context.getters.size + ',000 points.');
+    context.commit('PUSH_ERROR', 'Maximum of ' + (context.getters.size - 1) + ' ' + id + ' in a ' + context.getters.size + ',000 point army.');
   } else  if (item.max === 'Half or None' &&
               item.number > Math.ceil(requiredCount / 2)) {
     context.commit('PUSH_ERROR', 'Maximum of ' + Math.ceil(requiredCount / 2) + ' ' + id + ' per ' + requiredCount + ' ' + requiredSentence + '.');
@@ -264,7 +269,7 @@ function checkValidations (context, id, item) {
              item.number > requiredCount) {
     context.commit('PUSH_ERROR', 'Maximum of ' + requiredCount + ' ' + id + ' per ' + requiredCount + ' ' + requiredSentence + '.');
   } else if (item.number + homologousCount > item.max * context.getters.size) {
-    context.commit('PUSH_ERROR', 'Maximum of ' + (item.max * context.getters.size) + ' ' + id + ' per ' + context.getters.size + ',000 points.');
+    context.commit('PUSH_ERROR', 'Maximum of ' + (item.max * context.getters.size) + ' ' + id + ' in a ' + context.getters.size + ',000 point army.');
   }
 
   // magic items upgrades can't exceed number

--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -10,10 +10,10 @@ export default {
   label: (state) => state.label,
   magic: (state) => state.magic,
   pointsCost: (state) => Object.values(state.units)
-    .reduce((pointsCost, unit) => pointsCost + +unit.pointsCost, 0),
+    .reduce((pointsCost, unit) => pointsCost + unit.pointsCost, 0),
   printItems: (state) => state.printItems,
   printableItems: (state) => state.printableItems,
-  size: (state, getters) => Math.max(1, Math.floor(getters.pointsCost / 1000)),
+  size: (state, getters) => Math.max(1, Math.floor((getters.pointsCost+199) / 1000)),
   specialRules: (state) => state.specialRules,
   spells: (state) => state.spells,
   unitCount (state) {
@@ -26,10 +26,10 @@ export default {
             if (!unit.noCount) {
               unitCount += unit.number;
             }
-            
+
             if (unit.specialRules && unit.specialRules.includes('Skirmish')) {
               skirmishCount += unit.number;
-              
+
               if (!unit.armour) {
                 unarmouredSkirmishCount += unit.number;
               }


### PR DESCRIPTION
The hits value of Cathay Maneaters is missing.

"Tepo" has been corrected to "Teppo" in most places, but one place was missing.

And this puts Rhinox Riders in the same position as the list in the book, infantry before cavalry.