### PR TITLE
Fix permanent focus bug: Removed focusin event handling and hasFocus styles from UseUnit.vue

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -60,12 +60,6 @@ import { mapGetters } from 'vuex';
 
 import PrintItems from '@/components/Print/PrintItems';
 
-function removeHasFocusClass(element) {
-  Array.prototype.forEach.call(element.querySelectorAll('.hasFocus'), (element) => {
-    element.classList.remove('hasFocus');
-  });
-}
-
 export default {
   name: 'wm-selector',
   components: { PrintItems },
@@ -74,17 +68,6 @@ export default {
     local: window.location.hostname === 'localhost',
     version: process.env.VUE_APP_VERSION
   }),
-  mounted () {
-    document.addEventListener('focusin', (event) => {
-      if (event.target.closest('.hasFocus')) {
-        removeHasFocusClass(event.target.closest('.hasFocus'));
-      } else {
-        removeHasFocusClass(document);
-      }
-
-      event.target.classList.add('hasFocus');
-    });
-  }
 };
 </script>
 

--- a/src/components/Selector/UsedUnit.vue
+++ b/src/components/Selector/UsedUnit.vue
@@ -52,7 +52,6 @@ export default {
 
 <style lang="scss">
   .selector-view .used.unit {
-    &.hasFocus,
     &:hover {
       .upgrades {
         display: table;


### PR DESCRIPTION
There was a really annoying bug everytime I wanted to remove some units from a list where the "upgrades" panel would be permanently stuck on the list (if there were any remaining units).

This was because when you clicked on a unit, a `hasFocus` class was added on the `focusin` event. The problem was that also triggered the upgrade panel to stay on that unit *until another unit got that CSS class instead or you removed the unit completely*. 
I found that there was no other use for that class so I removed it and also the code that added it. You can add upgrades and navigate the list of units as usual now without being stuck forever with the panel.

To replicate the issue:
- Select any army and use the "Selector" specifically.
- Add a bunch of the same unit.
- Click on it once to remove one.
- You're now stuck with the Upgrades panel until you clicked on another one or completely remove that unit from the list.